### PR TITLE
Bump to 0.14.0+wasi-0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi"
-version = "0.13.4+wasi-0.2.3"
+version = "0.14.0+wasi-0.2.3"
 authors = ["The Cranelift Project Developers"]
 description = "WASI API bindings for Rust"
 categories = ["no-std", "wasm"]
@@ -18,7 +18,7 @@ repository = "https://github.com/bytecodealliance/wasi-rs"
 
 [workspace.dependencies]
 rand = { version = "0.8.5", default-features = false }
-wasi = { version = "0.13", path = ".", default-features = false }
+wasi = { version = "0.14", path = ".", default-features = false }
 
 [workspace]
 members = ["./crates/*"]


### PR DESCRIPTION
Bump to 0.14.0+wasi-0.2.3, from 0.13.4+wasi-0.2.3, as the update to wit-bindgen 0.37 includes some minor semver incompatibilies.