### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ members = ["./crates/*"]
 wit-bindgen-rt = { version = "0.39.0", features = ["bitflags"] }
 
 # When built as part of libstd
-compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 rustc-std-workspace-alloc = { version = "1.0", optional = true }
 
@@ -35,7 +34,7 @@ rustc-std-workspace-alloc = { version = "1.0", optional = true }
 default = ["std"]
 std = []
 # Unstable feature to support being a libstd dependency
-rustc-dep-of-std = ["compiler_builtins", "core", "rustc-std-workspace-alloc"]
+rustc-dep-of-std = ["core", "rustc-std-workspace-alloc"]
 
 [[example]]
 name = "cli-command-no_std"


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993