### PR TITLE
Add `#![no_std]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+#![no_std]
 pub use wasip2::*;


### PR DESCRIPTION
Lack of the attribute makes the crate to technically depend on `std`.